### PR TITLE
Update README.md

### DIFF
--- a/apps/README.md
+++ b/apps/README.md
@@ -14,7 +14,7 @@ public fun register_ua<UA>(account: &signer): UaCapability<UA>
 ```
 
 The `UA` type is an identifier of your application. You can use any type as `UA`, e.g. `0x1::MyApp::MyApp` as UA.
-Note: only one UA is allowed per address. That means there won't two `UA` types share the same address.
+Note: only one UA is allowed per address. This means that two UA types cannot share the same address.
 
 When calling `register_ua()`, you will get a `UaCapability<UA>` as return. It is the resources for authenticating any LayerZero functions, such as sending messages and setting configurations. 
 


### PR DESCRIPTION
In the "Register UA" section, the phrase "That means there won't two UA types share the same address" could be clarified for better grammar. For example: "This means that two UA types cannot share the same address."