### PR TITLE
Update README.md

### DIFF
--- a/apps/README.md
+++ b/apps/README.md
@@ -88,7 +88,7 @@ public fun lz_receive_types(src_chain_id: u64, src_address: vector<u8>, payload:
 ### Blocking Mode
 
 Layerzero is by default BLOCKING, which means if the message payload fails in the lz_receive function,
-your UA will be blocked and cannot receive next messages from that path until the failed message is received successfully.
+your UA will be blocked and will not be able to receive subsequent messages from that path until the failed message is successfully received.
 For that case, you may have to drop the message or store it and retry later. We provide [LzApp Modules](#LzApp-Modules) to help you handle it.
 
 


### PR DESCRIPTION
In the "Receive Messages" section, the phrase "your UA will be blocked and cannot receive next messages from that path until the failed message is received successfully" could be rephrased for clarity, such as "your UA will be blocked and will not be able to receive subsequent messages from that path until the failed message is successfully received."